### PR TITLE
Support git shortlink package references

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ var path = require('path');
 var fs = require('fs');
 var CordovaError = require('cordova-common').CordovaError;
 var isUrl = require('is-url');
+var hostedGitInfo = require('hosted-git-info');
 
 /*
  * A function that npm installs a module from npm or a git url
@@ -147,7 +148,10 @@ function getJsonDiff (obj1, obj2) {
 function trimID (target) {
     var parts;
     // If GITURL, set target to repo name
-    if (isUrl(target)) {
+    var gitInfo = hostedGitInfo.fromUrl(target);
+    if (gitInfo) {
+        target = gitInfo.project;
+    } else if (isUrl(target)) {
         // strip away .git and everything that follows
         var strippedTarget = target.split('.git');
         var re = /.*\/(.*)/;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "cordova-common": "2.1.1",
     "dependency-ls": "^1.1.0",
+    "hosted-git-info": "^2.5.0",
     "is-url": "^1.2.1",
     "q": "^1.4.1",
     "shelljs": "^0.7.0"

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -241,8 +241,8 @@ describe('test trimID method for npm and git', function () {
                 expect(fs.existsSync(result)).toBe(true);
                 expect(result).toMatch('cordova-plugin-device');
 
-                // refetch to trigger trimID
-                return fetch('https://github.com/apache/cordova-plugin-media.git', tmpDir, opts);
+                // refetch to trigger trimID, with shortcode URL
+                return fetch('github:apache/cordova-plugin-media', tmpDir, opts);
             })
             .then(function (result) {
                 expect(result).toBeDefined();


### PR DESCRIPTION
npm supports referencing git repos on "well-known" hosts with a syntax like `github:user/repo` or `bitbucket:user/repo`. Cordova-fetch currently fails to handle these references because they aren't detected by the `is-url` module.

This pulls in the same `hosted-git-info` module that npm uses to properly detect and support those references.