### PR TITLE
Enabling support for git+http

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ var path = require('path');
 var fs = require('fs');
 var CordovaError = require('cordova-common').CordovaError;
 var isUrl = require('is-url');
+var isGitUrl = require('is-git-url');
 var hostedGitInfo = require('hosted-git-info');
 
 /*
@@ -154,7 +155,7 @@ function trimID (target) {
     var gitInfo = hostedGitInfo.fromUrl(target);
     if (gitInfo) {
         target = gitInfo.project;
-    } else if (isUrl(target)) {
+    } else if (isUrl(target) || isGitUrl(target)) {
         // strip away .git and everything that follows
         var strippedTarget = target.split('.git');
         var re = /.*\/(.*)/;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dependency-ls": "^1.1.0",
     "hosted-git-info": "^2.5.0",
     "is-url": "^1.2.1",
+    "is-git-url": "^1.0.0",
     "q": "^1.4.1",
     "shelljs": "^0.7.0"
   },

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -283,6 +283,25 @@ describe('test trimID method for npm and git', function () {
             })
             .fin(done);
     }, 30000);
+
+    it('should fetch from git+http successfully', function (done) {
+        fetch('git+http://gitbox.apache.org/repos/asf/cordova-plugin-dialogs.git', tmpDir, opts)
+            .then(function () {
+                // refetch to trigger trimID
+                return fetch('git+http://gitbox.apache.org/repos/asf/cordova-plugin-dialogs.git', tmpDir, opts);
+            })
+            .then(function (result) {
+                var pkgJSON = require(path.join(result, 'package.json'));
+                expect(result).toBeDefined();
+                expect(fs.existsSync(result)).toBe(true);
+                expect(pkgJSON.name).toBe('cordova-plugin-dialogs');
+            })
+            .fail(function (err) {
+                console.error(err);
+                expect(err).toBeUndefined();
+            })
+            .fin(done);
+    }, 30000);
 });
 
 describe('fetch failure with unknown module', function () {


### PR DESCRIPTION
Currently Cordova returns a 501 for git+http fetching.  This enables the ability to reference git+http.  It would be nice if this could be applied to Cordova 7, since we aren't moving to 8 yet.  It definitely needs to be in 8 since nofetch is no longer supported.  (I assume it's just a matter of updating the package.json dependency in cordova-lib?)

Also, I tried writing a test for this.  However the unit tests are actually more like functional tests and hitting real endpoints.  I don't have a git+http endpoint to test with that isn't GitHub (the GitHub one is picked up by the hostedGitInfo logic).  So, I tested with my internal one that was the root of this problem.  I'll post the code here and you can decide how to integrate it into a test (perhaps mocking is in order).  This is part of the "test trimID method for npm and git".  What I actually want to test is JUST the trim method, so if it was exposed for testing, we wouldn't even have to make the fetch call per se, just verify the trimID function is working properly.
```    
it('should fetch from git+http successfully', function (done) {
        fetch('git+http://git.oclc.org/mobile/oclc-authentication-plugin.git', tmpDir, opts)
            .then(function () {
                // refetch to trigger trimID
                return fetch('git+http://git.oclc.org/mobile/oclc-authentication-plugin.git', tmpDir, opts);
            })
            .then(function (result) {
                var pkgJSON = require(path.join(result, 'package.json'));
                expect(result).toBeDefined();
                expect(fs.existsSync(result)).toBe(true);
                expect(pkgJSON.name).toBe('oclc-authentication-plugin');
            })
            .fail(function (err) {
                console.error(err);
                expect(err).toBeUndefined();
            })
            .fin(done);
    }, 30000);
```