### PR TITLE
CB-13503 fix trimID bug when using file:path/to/plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ function getJsonDiff (obj1, obj2) {
  * get the moduleID of the installed module.
  *
  * @param {String} target    target that was passed into cordova-fetch.
- *                           can be moduleID, moduleID@version or gitURL
+ *                           can be moduleID, moduleID@version, gitURL or relative path (file:relative/path)
  *
  * @return {String} ID       moduleID without version.
  */
@@ -166,6 +166,11 @@ function trimID (target) {
     }
 
     // If local path exists, try to get plugin id from package.json or set target to final directory
+    if (target.startsWith('file:')) {
+        // If target starts with file: prefix, strip it
+        target = target.substring(5);
+    }
+
     if (fs.existsSync(target)) {
         var pluginId;
         var pkgJsonPath = path.join(target, 'package.json');

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -208,6 +208,7 @@ describe('test trimID method for npm and git', function () {
 
     beforeEach(function () {
         tmpDir = helpers.tmpDir('plug_trimID');
+        shell.cp('-R', 'spec/support', path.join(tmpDir, 'support'));
         process.chdir(tmpDir);
     });
 
@@ -276,6 +277,26 @@ describe('test trimID method for npm and git', function () {
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
                 expect(result).toMatch('cordova-plugin-ms-adal');
+            })
+            .fail(function (err) {
+                console.error(err);
+                expect(err).toBeUndefined();
+            })
+            .fin(done);
+    }, 30000);
+
+    it('should fetch same plugin twice in a row if using a relative path', function (done) {
+        fetch('file:support/dummy-local-plugin', tmpDir, opts)
+            .then(function (result) {
+                expect(result).toBeDefined();
+                expect(fs.existsSync(result)).toBe(true);
+                expect(result).toMatch('test-plugin');
+                return fetch('file:support/dummy-local-plugin', tmpDir, opts);
+            })
+            .then(function (result) {
+                expect(result).toBeDefined();
+                expect(fs.existsSync(result)).toBe(true);
+                expect(result).toMatch('test-plugin');
             })
             .fail(function (err) {
                 console.error(err);

--- a/spec/support/dummy-local-plugin/package.json
+++ b/spec/support/dummy-local-plugin/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "test-plugin",
+  "version": "1.0.0",
+  "description": "This plugin allows you to stream audio and video in a fullscreen, native player on iOS and Android.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/spec/support/dummy-local-plugin/plugin.xml
+++ b/spec/support/dummy-local-plugin/plugin.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugin
+		xmlns="http://apache.org/cordova/ns/plugins/1.0"
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		id="test-plugin"
+		version="1.0.0">
+
+	<name>test plugin</name>
+
+	<engines>
+		<engine name="cordova" version=">=3.0.0" />
+	</engines>
+
+</plugin>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-13503

This PR fixes a bug that prevents cordova-fetch from installing plugins when using a local path in package.json, using the syntax :

```
"dependencies": {
  "my-plugin": "file:path/to/plugin",
  …
}
```

the syntax without **file:** works but as [the JIRA issue says](https://issues.apache.org/jira/browse/CB-13503), the **file:** prefix is added when running _cordova platform add_, making subsequent runs fail.

This PR also adds a test case with a dummy plugin that gets installed twice, in order to trigger the problematic call to trimID.