### PR TITLE
Simplify installation location retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,6 @@
   },
   "dependencies": {
     "cordova-common": "^2.2.0",
-    "dependency-ls": "^1.1.0",
-    "hosted-git-info": "^2.5.0",
-    "is-url": "^1.2.1",
-    "is-git-url": "^1.0.0",
     "q": "^1.4.1",
     "shelljs": "^0.7.0"
   },

--- a/spec/fetch-unit.spec.js
+++ b/spec/fetch-unit.spec.js
@@ -23,11 +23,10 @@ var superspawn = require('cordova-common').superspawn;
 
 describe('unit tests for index.js', function () {
     beforeEach(function () {
-        spyOn(superspawn, 'spawn').and.returnValue(true);
+        spyOn(superspawn, 'spawn').and.returnValue('+ foo@1.2.3');
         spyOn(shell, 'mkdir').and.returnValue(true);
         spyOn(shell, 'which').and.returnValue(Promise.resolve());
         spyOn(fetch, 'isNpmInstalled').and.returnValue(Promise.resolve());
-        spyOn(fetch, 'getPath').and.returnValue('some/path');
         spyOn(fs, 'existsSync').and.returnValue(false);
     });
 


### PR DESCRIPTION
This replaces the whole existing logic to determine the path of an installed package with a new one.
With this PR, we transparently support **all** spec formats that npm supports too.

Instead of a lot of guessing we just read the output of npm. Granted, parsing output that's intended for humans isn't perfect either, but I tried a lot of things and this is the only thing that get's the job done reliably and without a big performance impact.

There's still a few things that could be improved with this, but I wanted to get this out ASAP to get some feedback, especially I'd like to know whether you find this approach feasible. So consider this a proof of concept.

This supports all npm versions down to 3 (which are all that were bundled with node versions we support). The only possibly breaking change should be the removal of `getPath` which wasn't documented though.