### PR TITLE
CB-14172: Disable save-exact explicitly

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,12 +75,17 @@ function npmArgs (target, userOptions) {
     if (opts.production) {
         args.push('--production');
     }
+    // save-exact could be enabled through .npmrc, so make sure to disable it
+    // to match our desired behavior.
     if (opts.save_exact) {
         args.push('--save-exact');
-    } else if (opts.save) {
-        args.push('--save');
     } else {
-        args.push('--no-save');
+        args.push('--save-exact=false');
+        if (opts.save) {
+            args.push('--save');
+        } else {
+            args.push('--no-save');
+        }
     }
     return args;
 }


### PR DESCRIPTION
When left unconfigured, user-defined configuration (think .npmrc) could
affect the outcome of these operations, which is undesirable.