### PR TITLE
CB-14173 Fix cordova <platform|plugin> add --link

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,8 +69,7 @@ function installPackage (target, dest, opts) {
 function npmArgs (target, userOptions) {
     const opts = Object.assign({ production: true }, userOptions);
 
-    const operation = opts.link ? 'link' : 'install';
-    const args = [operation, target];
+    const args = ['install', target];
 
     if (opts.production) {
         args.push('--production');


### PR DESCRIPTION
This drops support for the untested and undocumented `link` option
which when set, caused `npm link` to be run instead of `npm install`.
However, the installed package's name cannot be extracted from the
output of `npm link`. Thus we always failed in that case.

Now, we always run `npm install` instead. This works for the use case of
`cordova <platform|plugin> add --link` since packages identified by a
local path are always installed as symbolic links by npm.