### PR TITLE
eslint devDep updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "eslint": "^4.19.1",
     "eslint-config-semistandard": "^11.0.0",
     "eslint-config-standard": "^10.2.1",
-    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-node": "^5.2.1",
-    "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-standard": "^3.0.1",
+    "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-standard": "^3.1.0",
     "file-url": "^2.0.2",
     "jasmine": "^2.4.1",
     "rewire": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "which": "^1.3.1"
   },
   "devDependencies": {
-    "eslint": "^3.19.0",
+    "eslint": "^4.19.1",
     "eslint-config-semistandard": "^11.0.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.8.0",


### PR DESCRIPTION
- eslint@4 devDep update
- in-range eslint-* devDep updates

**Testing:**

- [x] check that `eslint` & `npm test` succeed on AppVeyor CI
- [x] check that `eslint` & `npm test` succeed on Travis CI

**For discussion:**

Use eslint@5 with other major eslint-* updates, which would need eslint-config-standard@next until eslint-config-standard@12 is published ref: <https://github.com/standard/eslint-config-standard/issues/123>