### PR TITLE
[WIP] CB-14251 cordova-fetch@1.3.1 patch release (August 2018)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "4"
   - "6"
   - "8"
+  - "10"
 install:
   - "npm install"
 script:

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,10 @@
 -->
 # Cordova-fetch Release Notes
 
+### 1.3.1 (Aug 2, 2018)
+* [CB-14251](https://issues.apache.org/jira/browse/CB-14251) in-range cordova-common@^2.2.5 update (1.3.x only)
+* [GH-20](https://github.com/apache/cordova-fetch/pull/20) Fix repo url in package.json
+
 ### 1.3.0 (Dec 14, 2017)
 * [CB-13055](https://issues.apache.org/jira/browse/CB-13055): added workaround for when `jsonDiff` has more than one different key. 
 * Support git shortlink package references

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
   - nodejs_version: "4"
   - nodejs_version: "6"
   - nodejs_version: "8"
+  - nodejs_version: "10"
   
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-fetch",
-  "version": "1.3.1-dev",
+  "version": "1.3.1",
   "description": "Apache Cordova fetch module. Fetches from git and npm.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "email": "dev@cordova.apache.org"
   },
   "dependencies": {
-    "cordova-common": "^2.2.0",
+    "cordova-common": "^2.2.5",
     "dependency-ls": "^1.1.0",
     "hosted-git-info": "^2.5.0",
     "is-url": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/apache/cordova-lib"
+    "url": "https://github.com/apache/cordova-fetch"
   },
   "keywords": [
     "cordova",

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -39,40 +39,49 @@ describe('platform fetch/uninstall tests via npm & git', function () {
 
     it('should fetch and uninstall a cordova platform via npm & git', function (done) {
 
-        fetch('cordova-android', tmpDir, opts)
+        // cordova-wp8 which is now deprecated should never
+        // drop support for deprecated Node.js 4 version.
+        fetch('cordova-wp8', tmpDir, opts)
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
-                expect(pkgJSON.name).toBe('cordova-android');
+                expect(pkgJSON.name).toBe('cordova-wp8');
 
-                return uninstall('cordova-android', tmpDir, opts);
+                return uninstall('cordova-wp8', tmpDir, opts);
             })
             .then(function () {
-                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-android'))).toBe(false);
+                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-wp8'))).toBe(false);
 
-                return fetch('https://github.com/apache/cordova-ios.git', tmpDir, opts);
+                // https://github.com/apache/cordova-blackberry.git which is now deprecated
+                // should never drop suport for deprecated Node.js 4 version.
+                return fetch('https://github.com/apache/cordova-ubuntu.git', tmpDir, opts);
             })
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
-                expect(pkgJSON.name).toBe('cordova-ios');
+                expect(pkgJSON.name).toBe('cordova-ubuntu');
 
-                return uninstall('cordova-ios', tmpDir, opts);
+                return uninstall('cordova-ubuntu', tmpDir, opts);
             })
             .then(function () {
-                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-ios'))).toBe(false);
+                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-blackberry'))).toBe(false);
+                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-blackberry10'))).toBe(false);
 
+                // FUTURE TBD:
                 // return fetch('git+ssh://git@github.com/apache/cordova-browser.git#487d91d1ded96b8e2029f2ee90f12a8b20499f54', tmpDir, opts);
                 // can't test ssh right now as it is requiring ssh password
-                return fetch('https://github.com/apache/cordova-browser.git', tmpDir, opts);
+
+                // https://github.com/apache/cordova-blackberry.git which is now deprecated
+                // drop support for deprecated Node.js 4 version.
+                return fetch('https://github.com/apache/cordova-blackberry.git', tmpDir, opts);
             })
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
-                expect(pkgJSON.name).toBe('cordova-browser');
+                expect(pkgJSON.name).toBe('cordova-blackberry10');
             })
             .fail(function (err) {
                 console.error(err);


### PR DESCRIPTION
### Changes

__Changes for `1.3.1` patch release:__

- GH-20 Fix repo url in package.json
- in-range cordova-common@^2.2.5 update (1.3.x only)
- _quick workaround in `spec/fetch.spec.js` to continue working on deprecated Node.js 4 version_
- update version & RELEASENOTES for 1.3.1 patch release, according to <https://github.com/apache/cordova-coho/blob/master/docs/tools-release-process.md>, tagged as `1.3.1` in local repo (tag to be pushed upon merge of this PR)

__Post-`1.3.1` changes for `1.3.x`__

- [ ] increment version to 1.3.2-dev

### Major adaptations to tools-release-process

FUTURE TBD
<!-- FUTURE TBD ???:
- Commit to increment version to 1.3.2-dev actually shows the new "-dev" version number (1.3.2-dev)
- Incremented -dev version in 1.3.x patch release branch only. The -dev version in master branch was already incremented with new major release number in GH-27.
-->

### How to merge

- [ ] To be merged by pushing these commits to the `1.3.x` branch

### Testing

- [x] `npm audit` shows no vulnerabilities
- [x] `npm outdated --depth=0` shows no red entries
- [x] `coho audit-license-headers -r fetch` shows no missing license headers
- [x] `coho check-license -r fetch` shows no invalid licences (with `xmldom` manually verified to have acceptable MIT license option)
- [ ] `npm test` passes on AppVeyor CI
- [ ] `npm test` passes on Travis CI