### PR TITLE
CB-14251 patch release updates WIP

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
-    "fs-extra": "^6.0.1",
     "jasmine": "^2.4.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "test": "npm run eslint && npm run jasmine",
-    "eslint": "eslint index.js spec/fetch.spec.js",
+    "eslint": "eslint .",
     "jasmine": "jasmine spec/fetch.spec.js spec/fetch-unit.spec.js"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-standard": "^3.0.1",
+    "fs-extra": "^6.0.1",
     "jasmine": "^2.4.1"
   },
   "scripts": {

--- a/spec/fetch-unit.spec.js
+++ b/spec/fetch-unit.spec.js
@@ -33,7 +33,7 @@ describe('unit tests for index.js', function () {
     });
 
     it('npm install should be called with production flag (default)', function (done) {
-        var opts = { cwd: 'some/path', production: true, save: true};
+        var opts = { cwd: 'some/path', production: true, save: true };
         fetch('platform', 'tmpDir', opts)
             .then(function (result) {
                 expect(superspawn.spawn).toHaveBeenCalledWith('npm', jasmine.stringMatching(/production/), jasmine.any(Object));
@@ -59,7 +59,7 @@ describe('unit tests for index.js', function () {
     });
 
     it('noprod should turn production off', function (done) {
-        var opts = { cwd: 'some/path', production: false};
+        var opts = { cwd: 'some/path', production: false };
         fetch('platform', 'tmpDir', opts)
             .then(function (result) {
                 expect(superspawn.spawn).not.toHaveBeenCalledWith('npm', jasmine.stringMatching(/production/), jasmine.any(Object));
@@ -72,7 +72,7 @@ describe('unit tests for index.js', function () {
     });
 
     it('when save is false, no-save flag should be passed through', function (done) {
-        var opts = { cwd: 'some/path', production: true, save: false};
+        var opts = { cwd: 'some/path', production: true, save: false };
         fetch('platform', 'tmpDir', opts)
             .then(function (result) {
                 expect(superspawn.spawn).toHaveBeenCalledWith('npm', jasmine.stringMatching(/--no-save/), jasmine.any(Object));

--- a/spec/fetch-unit.spec.js
+++ b/spec/fetch-unit.spec.js
@@ -19,15 +19,14 @@
 var fetch = require('../index.js');
 var shell = require('shelljs');
 var fs = require('fs');
-var Q = require('q');
 var superspawn = require('cordova-common').superspawn;
 
 describe('unit tests for index.js', function () {
     beforeEach(function () {
         spyOn(superspawn, 'spawn').and.returnValue(true);
         spyOn(shell, 'mkdir').and.returnValue(true);
-        spyOn(shell, 'which').and.returnValue(Q());
-        spyOn(fetch, 'isNpmInstalled').and.returnValue(Q());
+        spyOn(shell, 'which').and.returnValue(Promise.resolve());
+        spyOn(fetch, 'isNpmInstalled').and.returnValue(Promise.resolve());
         spyOn(fetch, 'getPath').and.returnValue('some/path');
         spyOn(fs, 'existsSync').and.returnValue(false);
     });

--- a/spec/fetch-unit.spec.js
+++ b/spec/fetch-unit.spec.js
@@ -32,55 +32,35 @@ describe('unit tests for index.js', function () {
         spyOn(fs, 'existsSync').and.returnValue(false);
     });
 
-    it('npm install should be called with production flag (default)', function (done) {
+    it('npm install should be called with production flag (default)', function () {
         var opts = { cwd: 'some/path', production: true, save: true };
-        fetch('platform', 'tmpDir', opts)
+        return fetch('platform', 'tmpDir', opts)
             .then(function (result) {
                 expect(superspawn.spawn).toHaveBeenCalledWith('npm', jasmine.stringMatching(/production/), jasmine.any(Object));
-            })
-            .fail(function (err) {
-                console.error(err);
-                expect(err).toBeUndefined();
-            })
-            .fin(done);
+            });
     });
 
-    it('save-exact should be true if passed in', function (done) {
+    it('save-exact should be true if passed in', function () {
         var opts = { cwd: 'some/path', save_exact: true };
-        fetch('platform', 'tmpDir', opts)
+        return fetch('platform', 'tmpDir', opts)
             .then(function (result) {
                 expect(superspawn.spawn).toHaveBeenCalledWith('npm', jasmine.stringMatching(/save-exact/), jasmine.any(Object));
-            })
-            .fail(function (err) {
-                console.error(err);
-                expect(err).toBeUndefined();
-            })
-            .fin(done);
+            });
     });
 
-    it('noprod should turn production off', function (done) {
+    it('noprod should turn production off', function () {
         var opts = { cwd: 'some/path', production: false };
-        fetch('platform', 'tmpDir', opts)
+        return fetch('platform', 'tmpDir', opts)
             .then(function (result) {
                 expect(superspawn.spawn).not.toHaveBeenCalledWith('npm', jasmine.stringMatching(/production/), jasmine.any(Object));
-            })
-            .fail(function (err) {
-                console.error(err);
-                expect(err).toBeUndefined();
-            })
-            .fin(done);
+            });
     });
 
-    it('when save is false, no-save flag should be passed through', function (done) {
+    it('when save is false, no-save flag should be passed through', function () {
         var opts = { cwd: 'some/path', production: true, save: false };
-        fetch('platform', 'tmpDir', opts)
+        return fetch('platform', 'tmpDir', opts)
             .then(function (result) {
                 expect(superspawn.spawn).toHaveBeenCalledWith('npm', jasmine.stringMatching(/--no-save/), jasmine.any(Object));
-            })
-            .fail(function (err) {
-                console.error(err);
-                expect(err).toBeUndefined();
-            })
-            .fin(done);
+            });
     });
 });

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -277,9 +277,8 @@ describe('fetch failure with unknown module', function () {
     it('should fail fetching a module that does not exist on npm', function () {
         return fetch('NOTAMODULE', tmpDir, opts)
             .then(function (result) {
-                console.log('This should fail and it should not be seen');
-            })
-            .fail(function (err) {
+                fail('Expected promise to be rejected');
+            }, function (err) {
                 expect(err.message.code).toBe(1);
                 expect(err).toBeDefined();
             });
@@ -303,9 +302,8 @@ describe('fetch failure with git subdirectory', function () {
     it('should fail fetching a giturl which contains a subdirectory', function () {
         return fetch('https://github.com/apache/cordova-plugins.git#:keyboard', tmpDir, opts)
             .then(function (result) {
-                console.log('This should fail and it should not be seen');
-            })
-            .fail(function (err) {
+                fail('Expected promise to be rejected');
+            }, function (err) {
                 expect(err.message.code).toBe(1);
                 expect(err).toBeDefined();
             });

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -88,7 +88,7 @@ describe('platform fetch/uninstall tests via npm & git', function () {
                 expect(err).toBeUndefined();
             })
             .fin(done);
-    }, 60000);
+    }, 600000);
 });
 
 describe('platform fetch/uninstall test via npm & git tags with --save', function () {
@@ -207,7 +207,7 @@ describe('plugin fetch/uninstall test with --save', function () {
                 expect(err).toBeUndefined();
             })
             .fin(done);
-    }, 30000);
+    }, 300000);
 });
 
 describe('test trimID method for npm and git', function () {
@@ -271,7 +271,7 @@ describe('test trimID method for npm and git', function () {
                 expect(err).toBeUndefined();
             })
             .fin(done);
-    }, 40000);
+    }, 400000);
 
     it('should fetch same plugin twice in a row if git repo name differ from plugin id', function (done) {
         fetch('https://github.com/AzureAD/azure-activedirectory-library-for-cordova.git', tmpDir, opts)
@@ -291,7 +291,7 @@ describe('test trimID method for npm and git', function () {
                 expect(err).toBeUndefined();
             })
             .fin(done);
-    }, 30000);
+    }, 300000);
 });
 
 describe('fetch failure with unknown module', function () {
@@ -318,7 +318,7 @@ describe('fetch failure with unknown module', function () {
                 expect(err).toBeDefined();
             })
             .fin(done);
-    }, 30000);
+    }, 300000);
 });
 
 describe('fetch failure with git subdirectory', function () {
@@ -345,7 +345,7 @@ describe('fetch failure with git subdirectory', function () {
                 expect(err).toBeDefined();
             })
             .fin(done);
-    }, 30000);
+    }, 300000);
 });
 
 describe('scoped plugin fetch/uninstall tests via npm', function () {
@@ -375,5 +375,5 @@ describe('scoped plugin fetch/uninstall tests via npm', function () {
                 expect(err).toBeUndefined();
             })
             .fin(done);
-    }, 30000);
+    }, 300000);
 });

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -39,49 +39,40 @@ describe('platform fetch/uninstall tests via npm & git', function () {
 
     it('should fetch and uninstall a cordova platform via npm & git', function (done) {
 
-        // cordova-wp8 which is now deprecated should never
-        // drop support for deprecated Node.js 4 version.
-        fetch('cordova-wp8', tmpDir, opts)
+        fetch('cordova-android', tmpDir, opts)
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
-                expect(pkgJSON.name).toBe('cordova-wp8');
+                expect(pkgJSON.name).toBe('cordova-android');
 
-                return uninstall('cordova-wp8', tmpDir, opts);
+                return uninstall('cordova-android', tmpDir, opts);
             })
             .then(function () {
-                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-wp8'))).toBe(false);
+                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-android'))).toBe(false);
 
-                // https://github.com/apache/cordova-blackberry.git which is now deprecated
-                // should never drop suport for deprecated Node.js 4 version.
-                return fetch('https://github.com/apache/cordova-ubuntu.git', tmpDir, opts);
+                return fetch('https://github.com/apache/cordova-ios.git', tmpDir, opts);
             })
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
-                expect(pkgJSON.name).toBe('cordova-ubuntu');
+                expect(pkgJSON.name).toBe('cordova-ios');
 
-                return uninstall('cordova-ubuntu', tmpDir, opts);
+                return uninstall('cordova-ios', tmpDir, opts);
             })
             .then(function () {
-                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-blackberry'))).toBe(false);
-                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-blackberry10'))).toBe(false);
+                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-ios'))).toBe(false);
 
-                // FUTURE TBD:
                 // return fetch('git+ssh://git@github.com/apache/cordova-browser.git#487d91d1ded96b8e2029f2ee90f12a8b20499f54', tmpDir, opts);
                 // can't test ssh right now as it is requiring ssh password
-
-                // https://github.com/apache/cordova-blackberry.git which is now deprecated
-                // drop support for deprecated Node.js 4 version.
-                return fetch('https://github.com/apache/cordova-blackberry.git', tmpDir, opts);
+                return fetch('https://github.com/apache/cordova-browser.git', tmpDir, opts);
             })
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
-                expect(pkgJSON.name).toBe('cordova-blackberry10');
+                expect(pkgJSON.name).toBe('cordova-browser');
             })
             .fail(function (err) {
                 console.error(err);

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -39,40 +39,49 @@ describe('platform fetch/uninstall tests via npm & git', function () {
 
     it('should fetch and uninstall a cordova platform via npm & git', function (done) {
 
-        fetch('cordova-android', tmpDir, opts)
+        // cordova-wp8 which is now deprecated should never
+        // drop support for deprecated Node.js 4 version.
+        fetch('cordova-wp8', tmpDir, opts)
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
-                expect(pkgJSON.name).toBe('cordova-android');
+                expect(pkgJSON.name).toBe('cordova-wp8');
 
-                return uninstall('cordova-android', tmpDir, opts);
+                return uninstall('cordova-wp8', tmpDir, opts);
             })
             .then(function () {
-                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-android'))).toBe(false);
+                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-wp8'))).toBe(false);
 
-                return fetch('https://github.com/apache/cordova-ios.git', tmpDir, opts);
+                // https://github.com/apache/cordova-blackberry.git which is now deprecated
+                // should never drop suport for deprecated Node.js 4 version.
+                return fetch('https://github.com/apache/cordova-ubuntu.git', tmpDir, opts);
             })
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
-                expect(pkgJSON.name).toBe('cordova-ios');
+                expect(pkgJSON.name).toBe('cordova-ubuntu');
 
-                return uninstall('cordova-ios', tmpDir, opts);
+                return uninstall('cordova-ubuntu', tmpDir, opts);
             })
             .then(function () {
-                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-ios'))).toBe(false);
+                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-blackberry'))).toBe(false);
+                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-blackberry10'))).toBe(false);
 
+                // FUTURE TBD:
                 // return fetch('git+ssh://git@github.com/apache/cordova-browser.git#487d91d1ded96b8e2029f2ee90f12a8b20499f54', tmpDir, opts);
                 // can't test ssh right now as it is requiring ssh password
-                return fetch('https://github.com/apache/cordova-browser.git', tmpDir, opts);
+
+                // https://github.com/apache/cordova-blackberry.git which is now deprecated
+                // drop support for deprecated Node.js 4 version.
+                return fetch('https://github.com/apache/cordova-blackberry.git', tmpDir, opts);
             })
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
-                expect(pkgJSON.name).toBe('cordova-browser');
+                expect(pkgJSON.name).toBe('cordova-blackberry10');
             })
             .fail(function (err) {
                 console.error(err);

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -39,40 +39,49 @@ describe('platform fetch/uninstall tests via npm & git', function () {
 
     it('should fetch and uninstall a cordova platform via npm & git', function () {
 
-        return fetch('cordova-android', tmpDir, opts)
+        // cordova-wp8 which is now deprecated should never
+        // drop support for deprecated Node.js 4 version.
+        return fetch('cordova-wp8', tmpDir, opts)
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
-                expect(pkgJSON.name).toBe('cordova-android');
+                expect(pkgJSON.name).toBe('cordova-wp8');
 
-                return uninstall('cordova-android', tmpDir, opts);
+                return uninstall('cordova-wp8', tmpDir, opts);
             })
             .then(function () {
-                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-android'))).toBe(false);
+                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-wp8'))).toBe(false);
 
-                return fetch('https://github.com/apache/cordova-ios.git', tmpDir, opts);
+                // https://github.com/apache/cordova-blackberry.git which is now deprecated
+                // should never drop suport for deprecated Node.js 4 version.
+                return fetch('https://github.com/apache/cordova-ubuntu.git', tmpDir, opts);
             })
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
-                expect(pkgJSON.name).toBe('cordova-ios');
+                expect(pkgJSON.name).toBe('cordova-ubuntu');
 
-                return uninstall('cordova-ios', tmpDir, opts);
+                return uninstall('cordova-ubuntu', tmpDir, opts);
             })
             .then(function () {
-                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-ios'))).toBe(false);
+                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-blackberry'))).toBe(false);
+                expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-blackberry10'))).toBe(false);
 
+                // FUTURE TBD:
                 // return fetch('git+ssh://git@github.com/apache/cordova-browser.git#487d91d1ded96b8e2029f2ee90f12a8b20499f54', tmpDir, opts);
                 // can't test ssh right now as it is requiring ssh password
-                return fetch('https://github.com/apache/cordova-browser.git', tmpDir, opts);
+
+                // https://github.com/apache/cordova-blackberry.git which is now deprecated
+                // drop support for deprecated Node.js 4 version.
+                return fetch('https://github.com/apache/cordova-blackberry.git', tmpDir, opts);
             })
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
-                expect(pkgJSON.name).toBe('cordova-browser');
+                expect(pkgJSON.name).toBe('cordova-blackberry10');
             });
     }, 120000);
 });

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -37,9 +37,9 @@ describe('platform fetch/uninstall tests via npm & git', function () {
         shell.rm('-rf', tmpDir);
     });
 
-    it('should fetch and uninstall a cordova platform via npm & git', function (done) {
+    it('should fetch and uninstall a cordova platform via npm & git', function () {
 
-        fetch('cordova-android', tmpDir, opts)
+        return fetch('cordova-android', tmpDir, opts)
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
@@ -73,12 +73,7 @@ describe('platform fetch/uninstall tests via npm & git', function () {
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
                 expect(pkgJSON.name).toBe('cordova-browser');
-            })
-            .fail(function (err) {
-                console.error(err);
-                expect(err).toBeUndefined();
-            })
-            .fin(done);
+            });
     }, 60000);
 });
 
@@ -98,8 +93,8 @@ describe('platform fetch/uninstall test via npm & git tags with --save', functio
         shell.rm('-rf', tmpDir);
     });
 
-    it('should fetch and uninstall a cordova platform via npm & git tags/branches', function (done) {
-        fetch('cordova-android@5.1.1', tmpDir, opts)
+    it('should fetch and uninstall a cordova platform via npm & git tags/branches', function () {
+        return fetch('cordova-android@5.1.1', tmpDir, opts)
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
@@ -149,12 +144,7 @@ describe('platform fetch/uninstall test via npm & git tags with --save', functio
                 expect(rootPJ.dependencies['cordova-android']).toBe('git+https://github.com/apache/cordova-android.git#4.1.x');
 
                 return uninstall('cordova-android', tmpDir, opts);
-            })
-            .fail(function (err) {
-                console.error(err);
-                expect(err).toBeUndefined();
-            })
-            .fin(done);
+            });
     }, 150000);
 });
 
@@ -174,8 +164,8 @@ describe('plugin fetch/uninstall test with --save', function () {
         shell.rm('-rf', tmpDir);
     });
 
-    it('should fetch and uninstall a cordova plugin via git commit sha', function (done) {
-        fetch('https://github.com/apache/cordova-plugin-contacts.git#7db612115755c2be73a98dda76ff4c5fd9d8a575', tmpDir, opts)
+    it('should fetch and uninstall a cordova plugin via git commit sha', function () {
+        return fetch('https://github.com/apache/cordova-plugin-contacts.git#7db612115755c2be73a98dda76ff4c5fd9d8a575', tmpDir, opts)
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
@@ -192,12 +182,7 @@ describe('plugin fetch/uninstall test with --save', function () {
                 var rootPJ = JSON.parse(fs.readFileSync(path.join(tmpDir, 'package.json'), 'utf8'));
                 expect(Object.keys(rootPJ.dependencies).length).toBe(0);
                 expect(fs.existsSync(path.join(tmpDir, 'node_modules', 'cordova-plugin-contacts'))).toBe(false);
-            })
-            .fail(function (err) {
-                console.error(err);
-                expect(err).toBeUndefined();
-            })
-            .fin(done);
+            });
     }, 30000);
 });
 
@@ -216,8 +201,8 @@ describe('test trimID method for npm and git', function () {
         shell.rm('-rf', tmpDir);
     });
 
-    it('should fetch the same cordova plugin twice in a row', function (done) {
-        fetch('cordova-plugin-device', tmpDir, opts)
+    it('should fetch the same cordova plugin twice in a row', function () {
+        return fetch('cordova-plugin-device', tmpDir, opts)
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
@@ -256,16 +241,11 @@ describe('test trimID method for npm and git', function () {
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
                 expect(result).toMatch('cordova-plugin-media');
-            })
-            .fail(function (err) {
-                console.error(err);
-                expect(err).toBeUndefined();
-            })
-            .fin(done);
+            });
     }, 40000);
 
-    it('should fetch same plugin twice in a row if git repo name differ from plugin id', function (done) {
-        fetch('https://github.com/AzureAD/azure-activedirectory-library-for-cordova.git', tmpDir, opts)
+    it('should fetch same plugin twice in a row if git repo name differ from plugin id', function () {
+        return fetch('https://github.com/AzureAD/azure-activedirectory-library-for-cordova.git', tmpDir, opts)
             .then(function (result) {
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
@@ -276,12 +256,7 @@ describe('test trimID method for npm and git', function () {
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
                 expect(result).toMatch('cordova-plugin-ms-adal');
-            })
-            .fail(function (err) {
-                console.error(err);
-                expect(err).toBeUndefined();
-            })
-            .fin(done);
+            });
     }, 30000);
 });
 
@@ -299,16 +274,15 @@ describe('fetch failure with unknown module', function () {
         shell.rm('-rf', tmpDir);
     });
 
-    it('should fail fetching a module that does not exist on npm', function (done) {
-        fetch('NOTAMODULE', tmpDir, opts)
+    it('should fail fetching a module that does not exist on npm', function () {
+        return fetch('NOTAMODULE', tmpDir, opts)
             .then(function (result) {
                 console.log('This should fail and it should not be seen');
             })
             .fail(function (err) {
                 expect(err.message.code).toBe(1);
                 expect(err).toBeDefined();
-            })
-            .fin(done);
+            });
     }, 30000);
 });
 
@@ -326,16 +300,15 @@ describe('fetch failure with git subdirectory', function () {
         shell.rm('-rf', tmpDir);
     });
 
-    it('should fail fetching a giturl which contains a subdirectory', function (done) {
-        fetch('https://github.com/apache/cordova-plugins.git#:keyboard', tmpDir, opts)
+    it('should fail fetching a giturl which contains a subdirectory', function () {
+        return fetch('https://github.com/apache/cordova-plugins.git#:keyboard', tmpDir, opts)
             .then(function (result) {
                 console.log('This should fail and it should not be seen');
             })
             .fail(function (err) {
                 expect(err.message.code).toBe(1);
                 expect(err).toBeDefined();
-            })
-            .fin(done);
+            });
     }, 30000);
 });
 
@@ -353,18 +326,13 @@ describe('scoped plugin fetch/uninstall tests via npm', function () {
         shell.rm('-rf', tmpDir);
     });
 
-    it('should fetch a scoped plugin from npm', function (done) {
-        fetch('@stevegill/cordova-plugin-device', tmpDir, opts)
+    it('should fetch a scoped plugin from npm', function () {
+        return fetch('@stevegill/cordova-plugin-device', tmpDir, opts)
             .then(function (result) {
                 var pkgJSON = require(path.join(result, 'package.json'));
                 expect(result).toBeDefined();
                 expect(fs.existsSync(result)).toBe(true);
                 expect(pkgJSON.name).toBe('@stevegill/cordova-plugin-device');
-            })
-            .fail(function (err) {
-                console.error(err);
-                expect(err).toBeUndefined();
-            })
-            .fin(done);
+            });
     }, 30000);
 });

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -74,7 +74,7 @@ describe('platform fetch/uninstall tests via npm & git', function () {
                 expect(fs.existsSync(result)).toBe(true);
                 expect(pkgJSON.name).toBe('cordova-browser');
             });
-    }, 60000);
+    }, 120000);
 });
 
 describe('platform fetch/uninstall test via npm & git tags with --save', function () {

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -79,7 +79,7 @@ describe('platform fetch/uninstall tests via npm & git', function () {
                 expect(err).toBeUndefined();
             })
             .fin(done);
-    }, 600000);
+    }, 60000);
 });
 
 describe('platform fetch/uninstall test via npm & git tags with --save', function () {
@@ -198,7 +198,7 @@ describe('plugin fetch/uninstall test with --save', function () {
                 expect(err).toBeUndefined();
             })
             .fin(done);
-    }, 300000);
+    }, 30000);
 });
 
 describe('test trimID method for npm and git', function () {
@@ -262,7 +262,7 @@ describe('test trimID method for npm and git', function () {
                 expect(err).toBeUndefined();
             })
             .fin(done);
-    }, 400000);
+    }, 40000);
 
     it('should fetch same plugin twice in a row if git repo name differ from plugin id', function (done) {
         fetch('https://github.com/AzureAD/azure-activedirectory-library-for-cordova.git', tmpDir, opts)
@@ -282,7 +282,7 @@ describe('test trimID method for npm and git', function () {
                 expect(err).toBeUndefined();
             })
             .fin(done);
-    }, 300000);
+    }, 30000);
 });
 
 describe('fetch failure with unknown module', function () {
@@ -309,7 +309,7 @@ describe('fetch failure with unknown module', function () {
                 expect(err).toBeDefined();
             })
             .fin(done);
-    }, 300000);
+    }, 30000);
 });
 
 describe('fetch failure with git subdirectory', function () {
@@ -336,7 +336,7 @@ describe('fetch failure with git subdirectory', function () {
                 expect(err).toBeDefined();
             })
             .fin(done);
-    }, 300000);
+    }, 30000);
 });
 
 describe('scoped plugin fetch/uninstall tests via npm', function () {
@@ -366,5 +366,5 @@ describe('scoped plugin fetch/uninstall tests via npm', function () {
                 expect(err).toBeUndefined();
             })
             .fin(done);
-    }, 300000);
+    }, 30000);
 });


### PR DESCRIPTION
### Changes

For patch release from `1.3.x` branch:

- [x] _rebase some test updates from master_
- [x] quick workaround needed in `spec/fetch.spec.js` to continue working on deprecated Node.js 4 version
- [ ] quick 10x timeouts in fetch.spec.js (NOT WANTED in master)
- [ ] rebase _more_ test updates from master
- [ ] GH-20 Fix repo url in package.json (cherry-pick from master)
- [ ] TBD ...

__Notes:__

- _TBD ..._

### Major adaptations to patch release process

- [ ] TBD ...

### Testing

- [ ] `npm audit` shows no vulnerabilities
- [ ] `npm outdated --depth=0` shows no red entries
- [ ] `coho audit-license-headers -r fetch` shows no missing license headers
- [ ] `coho check-license -r fetch` shows no invalid licences (with `xmldom` manually verified to have acceptable MIT license option)
- [ ] `npm test` passes on AppVeyor CI
- [ ] `npm test` passes on Travis CI
- [ ] TBD ...