### PR TITLE
package.json fix eslint script to be more explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "test": "npm run eslint && npm run jasmine",
-    "eslint": "eslint .",
+    "eslint": "eslint *.js spec",
     "jasmine": "jasmine spec/fetch.spec.js spec/fetch-unit.spec.js"
   },
   "engines": {


### PR DESCRIPTION
needed to avoid running eslint on ~~external~~ node_modules _as installed by `npm install`_