### PR TITLE
[WIP] unit testing of module ID in internal getPath() call (1.3.x)

### DIFF
--- a/spec/fetch-unit.spec.js
+++ b/spec/fetch-unit.spec.js
@@ -115,6 +115,46 @@ describe('more unit tests for index.js: internal getPath() call', function () {
             });
     });
 
+    it('internal getPath to be called with correct arguments for: git+http://scm.service.io/user/my-repo://scm.service.io/user/my-repo', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git+http://scm.service.io/user/my-repo://scm.service.io/user/my-repo';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git+https://scm.service.io/user/my-repo://scm.service.io/user/my-repo', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git+https://scm.service.io/user/my-repo://scm.service.io/user/my-repo';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: file://my/path/to/my-repo', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'file://my/path/to/my-repo';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: /my/path/to/my-repo', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = '/my/path/to/my-repo';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
     it('internal getPath to be called with correct arguments for: https://scm.service.io/user/my-repo#old-tag', function () {
         var opts = { cwd: 'some/path', production: true, save: true };
         var url = 'https://scm.service.io/user/my-repo#old-tag';
@@ -128,6 +168,26 @@ describe('more unit tests for index.js: internal getPath() call', function () {
     it('internal getPath to be called with correct arguments for: git://scm.service.io/user/my-repo#old-tag', function () {
         var opts = { cwd: 'some/path', production: true, save: true };
         var url = 'git://scm.service.io/user/my-repo#old-tag';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git+http://scm.service.io/user/my-repo#old-tag', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git+http://scm.service.io/user/my-repo#old-tag';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git+https://scm.service.io/user/my-repo#old-tag', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git+https://scm.service.io/user/my-repo#old-tag';
         return fetch(url, 'tmpDir', opts)
             .then(function (result) {
                 expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
@@ -155,6 +215,26 @@ describe('more unit tests for index.js: internal getPath() call', function () {
             });
     });
 
+    it('internal getPath to be called with correct arguments for: git+http://scm.service.io/user/my-repo.git', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git+http://scm.service.io/user/my-repo.git';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git+https://scm.service.io/user/my-repo.git', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git+https://scm.service.io/user/my-repo.git';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
     it('internal getPath to be called with correct arguments for: https://scm.service.io/user/my-repo.git#old-tag', function () {
         var opts = { cwd: 'some/path', production: true, save: true };
         var url = 'https://scm.service.io/user/my-repo.git#old-tag';
@@ -175,6 +255,26 @@ describe('more unit tests for index.js: internal getPath() call', function () {
             });
     });
 
+    it('internal getPath to be called with correct arguments for: git+http://scm.service.io/user/my-repo.git#old-tag', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git+http://scm.service.io/user/my-repo.git#old-tag';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git+https://scm.service.io/user/my-repo.git#old-tag', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git+https://scm.service.io/user/my-repo.git#old-tag';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
     it('internal getPath to be called with correct arguments for: https://scm.git.service.io/user/my-repo.git', function () {
         var opts = { cwd: 'some/path', production: true, save: true };
         var url = 'https://scm.git.service.io/user/my-repo.git';
@@ -188,6 +288,26 @@ describe('more unit tests for index.js: internal getPath() call', function () {
     it('internal getPath to be called with correct arguments for: git://scm.git.service.io/user/my-repo.git', function () {
         var opts = { cwd: 'some/path', production: true, save: true };
         var url = 'git://scm.git.service.io/user/my-repo.git';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git+http://scm.git.service.io/user/my-repo.git', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git+http://scm.git.service.io/user/my-repo.git';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git+https://scm.git.service.io/user/my-repo.git', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git+https://scm.git.service.io/user/my-repo.git';
         return fetch(url, 'tmpDir', opts)
             .then(function (result) {
                 expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);

--- a/spec/fetch-unit.spec.js
+++ b/spec/fetch-unit.spec.js
@@ -315,6 +315,46 @@ describe('more unit tests for index.js: internal getPath() call', function () {
             });
     });
 
+    it('internal getPath to be called with correct arguments for: https://scm.git.service.io/user/my-repo.git#old-tag', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'https://scm.git.service.io/user/my-repo.git#old-tag';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git://scm.git.service.io/user/my-repo.git#old-tag', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git://scm.git.service.io/user/my-repo.git#old-tag';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git+http://scm.git.service.io/user/my-repo.git#old-tag', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git+http://scm.git.service.io/user/my-repo.git#old-tag';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git+https://scm.git.service.io/user/my-repo.git#old-tag', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git+https://scm.git.service.io/user/my-repo.git#old-tag';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
     it('internal getPath to be called with correct arguments for: https://scm.service.io/user/my-repo-other-url', function () {
         var opts = { cwd: 'some/path', production: true, save: true };
         var url = 'https://scm.service.io/user/my-repo-other-url';

--- a/spec/fetch-unit.spec.js
+++ b/spec/fetch-unit.spec.js
@@ -84,3 +84,124 @@ describe('unit tests for index.js', function () {
             .fin(done);
     });
 });
+
+describe('more unit tests for index.js: internal getPath() call', function () {
+    beforeEach(function () {
+        spyOn(superspawn, 'spawn').and.returnValue(Promise.resolve('+ my-repo@2.0.0'));
+        spyOn(shell, 'mkdir').and.returnValue(true);
+        spyOn(shell, 'which').and.returnValue(Q());
+        spyOn(fetch, 'isNpmInstalled').and.returnValue(Q());
+        spyOn(fetch, 'getPath').and.returnValue('some/path/to/my-repo');
+        spyOn(fs, 'existsSync').and.returnValue(false);
+    });
+
+    it('internal getPath to be called with correct arguments for: https://scm.service.io/user/my-repo', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'https://scm.service.io/user/my-repo';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git://scm.service.io/user/my-repo', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git://scm.service.io/user/my-repo';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: https://scm.service.io/user/my-repo#old-tag', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'https://scm.service.io/user/my-repo#old-tag';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git://scm.service.io/user/my-repo#old-tag', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git://scm.service.io/user/my-repo#old-tag';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: https://scm.service.io/user/my-repo.git', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'https://scm.service.io/user/my-repo.git';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git://scm.service.io/user/my-repo.git', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git://scm.service.io/user/my-repo.git';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: https://scm.service.io/user/my-repo.git#old-tag', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'https://scm.service.io/user/my-repo.git#old-tag';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git://scm.service.io/user/my-repo.git#old-tag', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git://scm.service.io/user/my-repo.git#old-tag';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: https://scm.git.service.io/user/my-repo.git', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'https://scm.git.service.io/user/my-repo.git';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: git://scm.git.service.io/user/my-repo.git', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'git://scm.git.service.io/user/my-repo.git';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+
+    it('internal getPath to be called with correct arguments for: https://scm.service.io/user/my-repo-other-url', function () {
+        var opts = { cwd: 'some/path', production: true, save: true };
+        var url = 'https://scm.service.io/user/my-repo-other-url';
+        return fetch(url, 'tmpDir', opts)
+            .then(function (result) {
+                expect(fetch.getPath).toHaveBeenCalledWith('my-repo', jasmine.stringMatching(/node_modules$/), url);
+                expect(result).toBe('some/path/to/my-repo');
+            });
+    });
+});


### PR DESCRIPTION
From review of PR #38 for `1.3.1` patch release on `1.3.x` branch we discovered a rare issue where the code would use the wrong module ID in case of a URL like `https://scm.git.service.io/user/my-repo.git`.

There was also a question if the changes in PR #38 may lead to a rare issue in case of a URL like `git://scm.git.service.io/user/my-repo.git`.

This WIP PR includes unit testing to check the results of the internal `getPath()` call on some URL variations, fails due to some module ID inconsistencies in case of the following URLs _(may have missed a few)_:
- `https://scm.git.service.io/user/my-repo.git` _(XXX TODO try these with plain `http`)_
- `git://scm.git.service.io/user/my-repo.git`
- _`git+http://scm.git.service.io/user/my-repo.git`_
- _`git+https://scm.git.service.io/user/my-repo.git`_
- `https://scm.service.io/user/my-repo-other-url` where `npm` indicates that it installed `my-repo@2.0.0`
- _`file://my/path/to/my-repo`_
- _`/my/path/to/my-repo` (XXX TODO test path starting with `.` & `..`)_
- `https://scm.service.io/user/my-repo#old-tag`
- `git://scm.service.io/user/my-repo#old-tag`
- _`git+http://scm.service.io/user/my-repo#old-tag`_
- _`git+https://scm.service.io/user/my-repo#old-tag`_
- _`git+http://scm.service.io/user/my-repo.git` (solved by changes proposed in PR #38)_
- _`git+https://scm.service.io/user/my-repo.git` (solved by changes proposed in PR #38)_
- _`git+http://scm.service.io/user/my-repo.git#old-tag` (solved by changes proposed in PR #38)_
- _`git+https://scm.service.io/user/my-repo.git#old-tag` (solved by changes proposed in PR #38)_
- _`https://scm.git.service.io/user/my-repo.git#old-tag`_
- _`git://scm.git.service.io/user/my-repo.git#old-tag`_
- _`git+http://scm.git.service.io/user/my-repo.git#old-tag`_
- _`git+https://scm.git.service.io/user/my-repo.git#old-tag`_

~~The exact same~~ _Most of the_ failures show up on `1.3.x` with or without the changes proposed in PR #38.

Note that it is not possible to run these exact unit tests on `master` due to some changes in the internal implementation. I think it is necessary to add similar unit tests to `master` to ensure that this kind of issue is resolved and does not come back in the future.