### PR TITLE
Add test coverage command in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 package-lock.json
+.nyc_output/
+coverage/

--- a/package.json
+++ b/package.json
@@ -43,10 +43,9 @@
     "nyc": "^12.0.2"
   },
   "scripts": {
-    "test": "npm run eslint && npm run jasmine",
-    "cover": "nyc jasmine --config=spec/coverage.json",
-    "eslint": "eslint .",
-    "jasmine": "jasmine spec/fetch.spec.js spec/fetch-unit.spec.js"
+    "test": "npm run eslint && npm run cover",
+    "cover": "nyc jasmine",
+    "eslint": "eslint --ignore-path .gitignore ."
   },
   "engines": {
     "node": ">= 6",

--- a/package.json
+++ b/package.json
@@ -39,15 +39,26 @@
     "eslint-plugin-standard": "^3.1.0",
     "file-url": "^2.0.2",
     "jasmine": "^2.4.1",
-    "rewire": "^4.0.1"
+    "rewire": "^4.0.1",
+    "nyc": "^12.0.2"
   },
   "scripts": {
     "test": "npm run eslint && npm run jasmine",
+    "cover": "nyc jasmine --config=spec/coverage.json",
     "eslint": "eslint .",
     "jasmine": "jasmine spec/fetch.spec.js spec/fetch-unit.spec.js"
   },
   "engines": {
     "node": ">= 6",
     "npm": ">= 3"
+  },
+  "nyc": {
+    "include": [
+      "index.js"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ]
   }
 }

--- a/spec/coverage.json
+++ b/spec/coverage.json
@@ -1,0 +1,8 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+      "*[sS]pec.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/spec/coverage.json
+++ b/spec/coverage.json
@@ -1,8 +1,0 @@
-{
-  "spec_dir": "spec",
-  "spec_files": [
-      "*[sS]pec.js"
-  ],
-  "stopSpecOnExpectationFailure": false,
-  "random": false
-}


### PR DESCRIPTION
This PR is simply adding new command `npm run cover` as in cordova-ios, cordova-common and etc.
No changes in module itself.

The result of this command is as follows,
```
$ npm run cover
...
> nyc jasmine --config=spec/coverage.json

Started
.................


17 specs, 0 failures
Finished in 88.889 seconds

----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |    86.89 |    66.67 |    88.89 |    86.89 |                   |
 index.js |    86.89 |    66.67 |    88.89 |    86.89 |... 08,121,146,163 |
----------|----------|----------|----------|----------|-------------------|
```
