### PR TITLE
Handle broken NODE_PATH setups gracefully

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,8 +125,9 @@ function pathToInstalledPackage (spec, dest) {
 // from `basedir`
 function resolvePathToPackage (name, basedir) {
     return Promise.resolve().then(_ => {
-        const { NODE_PATH } = process.env;
-        const paths = NODE_PATH ? NODE_PATH.split(path.delimiter) : [];
+        const paths = (process.env.NODE_PATH || '')
+            .split(path.delimiter)
+            .filter(p => p);
 
         // We resolve the path to the module's package.json to avoid getting the
         // path to `main` which could be located anywhere in the package


### PR DESCRIPTION
Previously, when NODE_PATH had a trailing separator like `/foo:/bar:`, resolving a module would hang indefinitely when the module was not found. This PR fixes that.

The bug was introduced in #44.