### PR TITLE
dependency updates (cordova-common@3, etc.)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-standard": "^4.0.0",
     "file-url": "^2.0.2",
-    "jasmine": "^3.1.0",
+    "jasmine": "^3.3.0",
     "rewire": "^4.0.1",
     "nyc": "^13.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "email": "dev@cordova.apache.org"
   },
   "dependencies": {
-    "cordova-common": "^2.2.0",
-    "fs-extra": "^6.0.1",
+    "cordova-common": "^3.0.0",
+    "fs-extra": "^7.0.0",
     "npm-package-arg": "^6.1.0",
     "pify": "^4.0.0",
     "resolve": "^1.8.1",
@@ -30,17 +30,17 @@
     "which": "^1.3.1"
   },
   "devDependencies": {
-    "eslint": "^4.19.1",
-    "eslint-config-semistandard": "^11.0.0",
-    "eslint-config-standard": "^10.2.1",
+    "eslint": "^5.8.0",
+    "eslint-config-semistandard": "^13.0.0",
+    "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-node": "^5.2.1",
-    "eslint-plugin-promise": "^3.8.0",
-    "eslint-plugin-standard": "^3.1.0",
+    "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "eslint-plugin-standard": "^4.0.0",
     "file-url": "^2.0.2",
-    "jasmine": "^2.4.1",
+    "jasmine": "^3.1.0",
     "rewire": "^4.0.1",
-    "nyc": "^12.0.2"
+    "nyc": "^13.0.0"
   },
   "scripts": {
     "test": "npm run eslint && npm run cover",

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -81,7 +81,7 @@ describe('fetch/uninstall tests via npm & git', function () {
 describe('fetch/uninstall with --save', function () {
 
     beforeEach(function () {
-        opts = {save: true};
+        opts = { save: true };
         // copy package.json from spec directory to tmpDir
         fs.copySync(path.join(__dirname, 'testpkg.json'), 'package.json');
     });
@@ -93,7 +93,7 @@ describe('fetch/uninstall with --save', function () {
                 name: 'cordova-android',
                 version: '5.1.1'
             }))
-            .then(_ => expectDependenciesToBe({'cordova-android': '^5.1.1'}))
+            .then(_ => expectDependenciesToBe({ 'cordova-android': '^5.1.1' }))
             .then(_ => uninstall('cordova-android', tmpDir, opts))
             .then(_ => expectDependenciesToBe({}))
             .then(_ => expectNotToBeInstalled('cordova-android'))
@@ -103,7 +103,7 @@ describe('fetch/uninstall with --save', function () {
                 name: 'cordova-ios',
                 version: '4.1.1'
             }))
-            .then(_ => expectDependenciesToBe({'cordova-ios': 'git+https://github.com/apache/cordova-ios.git#rel/4.1.1'}))
+            .then(_ => expectDependenciesToBe({ 'cordova-ios': 'git+https://github.com/apache/cordova-ios.git#rel/4.1.1' }))
             .then(_ => uninstall('cordova-ios', tmpDir, opts))
             .then(_ => expectDependenciesToBe({}))
             .then(_ => expectNotToBeInstalled('cordova-ios'))
@@ -113,7 +113,7 @@ describe('fetch/uninstall with --save', function () {
                 name: 'cordova-android',
                 version: '4.1.1'
             }))
-            .then(_ => expectDependenciesToBe({'cordova-android': 'git+https://github.com/apache/cordova-android.git#4.1.x'}))
+            .then(_ => expectDependenciesToBe({ 'cordova-android': 'git+https://github.com/apache/cordova-android.git#4.1.x' }))
             .then(_ => uninstall('cordova-android', tmpDir, opts));
     }, 150000);
 
@@ -124,7 +124,7 @@ describe('fetch/uninstall with --save', function () {
                 name: 'cordova-plugin-contacts',
                 version: '2.0.2-dev'
             }))
-            .then(_ => expectDependenciesToBe({'cordova-plugin-contacts': `git+${URL}`}))
+            .then(_ => expectDependenciesToBe({ 'cordova-plugin-contacts': `git+${URL}` }))
             .then(_ => uninstall('cordova-plugin-contacts', tmpDir, opts))
             .then(_ => expectDependenciesToBe({}))
             .then(_ => expectNotToBeInstalled('cordova-plugin-contacts'));


### PR DESCRIPTION
It appears that Jasmine 3.3.0 works here, although we might want to pin it to `~3.1.0` just for consistency