### PR TITLE
Properly detect npm install package name

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,15 +92,16 @@ function npmArgs (target, userOptions) {
 
 function getTargetPackageSpecFromNpmInstallOutput (npmInstallOutput) {
     const lines = npmInstallOutput.split('\n');
-    if (lines[0].startsWith('+ ')) {
-        // npm >= 5
-        return lines[0].slice(2);
-    } else if (lines[1].startsWith('└─') || lines[1].startsWith('`-')) {
-        // 3 <= npm <= 4
-        return lines[1].slice(4).split(' ')[0];
-    } else {
-        throw new CordovaError('Could not determine package name from output:\n' + npmInstallOutput);
+    for (let i = 0; i < lines.length; i++) {
+        if (lines[i].startsWith('+ ')) {
+            // npm >= 5
+            return lines[i].slice(2);
+        } else if (lines[i].startsWith('└─') || lines[i].startsWith('`-')) {
+            // 3 <= npm <= 4
+            return lines[i].slice(4).split(' ')[0];
+        }
     }
+    throw new CordovaError('Could not determine package name from output:\n' + npmInstallOutput);
 }
 
 // Resolves to installation path of package defined by spec if the right version

--- a/spec/fetch-unit.spec.js
+++ b/spec/fetch-unit.spec.js
@@ -78,6 +78,44 @@ describe('npmArgs', function () {
     });
 });
 
+describe('getTargetPackageSpecFromNpmInstallOutput', () => {
+    const fetch = rewire('..');
+    const getTargetPackageSpecFromNpmInstallOutput = fetch.__get__('getTargetPackageSpecFromNpmInstallOutput');
+    const outputSampleNpm5 = '+ cordova-electron@1.0.0-dev';
+    const outputSampleNpm3 = 'helloworld@1.0.0 /cordova-project\n' +
+                             '└─┬ cordova-electron@1.0.0-dev  (git://github.com/apache/cordova-electron.git)';
+    const outputSampleNpm5WithPostinstall = '> electron@3.1.1 postinstall /cordova-project/node_modules/electron\n' +
+                                            '> node install.js\n\n' +
+                                            '+ cordova-electron@1.0.0-dev\n';
+    const outputSampleNpm3WithPostinstall = '> electron@3.1.1 postinstall /cordova-project/node_modules/electron\n' +
+                                            '> node install.js\n' +
+                                            'helloworld@1.0.0 /cordova-project\n' +
+                                            '└─┬ cordova-electron@1.0.0-dev  (git://github.com/apache/cordova-electron.git)';
+    const wrongOutputSample = 'Wrong output';
+
+    it('should parse the package name using  npm >= 5', () => {
+        expect(getTargetPackageSpecFromNpmInstallOutput(outputSampleNpm5)).toEqual('cordova-electron@1.0.0-dev');
+    });
+
+    it('should parse the package name using npm 3 <= npm <= 4', () => {
+        expect(getTargetPackageSpecFromNpmInstallOutput(outputSampleNpm3)).toEqual('cordova-electron@1.0.0-dev');
+    });
+
+    it('should parse the package name using npm >= 5 with postinstall ', () => {
+        expect(getTargetPackageSpecFromNpmInstallOutput(outputSampleNpm5WithPostinstall)).toEqual('cordova-electron@1.0.0-dev');
+    });
+
+    it('should parse the package name using npm 3 <= npm <= 4 with postinstall', () => {
+        expect(getTargetPackageSpecFromNpmInstallOutput(outputSampleNpm3WithPostinstall)).toEqual('cordova-electron@1.0.0-dev');
+    });
+
+    it('should gracefully handle if could not determine the package name from output', () => {
+        expect(() => {
+            getTargetPackageSpecFromNpmInstallOutput(wrongOutputSample);
+        }).toThrow(new Error('Could not determine package name from output:\n' + wrongOutputSample));
+    });
+});
+
 describe('resolvePathToPackage', () => {
     let tmpDir, resolvePathToPackage, expectedPath, NODE_PATH;
 


### PR DESCRIPTION
**What does this PR do?**
------------------------------------------

Fix issue #59, where in Nightly in the `getTargetPackageSpecFromNpmInstallOutput` method, if the dependency or sub-dependency have a postinstall, for example electron package, it will print out extra lines.

```
> electron@3.1.1 postinstall /cordova-project/node_modules/electron
> node install.js 
```

Because of this additional prinout, the `getTargetPackageSpecFromNpmInstallOutput` method fails to parse properly the printout for the package name.


------------------------------------------
### Fix added loop throught npmInstallOutput:
------------------------------------------

Loop throught the npm install output and look for the particular format that contains the package name.

------------------------------------------
### Test
------------------------------------------

Tested with 3 node version 6.16.0, 8.15.0 and 10.15.0 using following tests.

```
$ npx cordova@nightly create cordova-project
$ cd cordova-project
$ npx cordova@nightly platform add github:apache/cordova-electron

```
I have implemented and ran tests for `getTargetPackageSpecFromNpmInstallOutput`. 
```
$ npm t

29 specs, 0 failures
Finished in 103.501 seconds
----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |    92.86 |     87.1 |    91.67 |    92.86 |                   |
 index.js |    92.86 |     87.1 |    91.67 |    92.86 |43,118,149,174,191 |
----------|----------|----------|----------|----------|-------------------|`
```