### PR TITLE
Only check once for installed npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,9 +145,12 @@ function resolvePathToPackage (name, basedir) {
  * @return {Promise<string>} Absolute path to npm.
  */
 function isNpmInstalled () {
-    return which('npm').catch(_ => {
-        throw new CordovaError('"npm" command line tool is not installed: make sure it is accessible on your PATH.');
-    });
+    if (!isNpmInstalled._cache) {
+        isNpmInstalled._cache = which('npm').catch(_ => {
+            throw new CordovaError('"npm" command line tool is not installed: make sure it is accessible on your PATH.');
+        });
+    }
+    return isNpmInstalled._cache;
 }
 
 module.exports.isNpmInstalled = isNpmInstalled;


### PR DESCRIPTION
### Motivation and Context
This is a minor change that should slightly improve performance of all methods exposed by this module by caching a file system lookup of `npm`.

### Description
<!-- Describe your changes in detail -->
Up until now we used `which` to ensure `npm` is available before we call it. Every time we want to use it.
With this change, we cache the result of the first call to `isNpmInstalled` and use that from there on.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Existing tests pass, no tests added to test the caching itself.

