### PR TITLE
chore: drop node 6 and 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 git:
   depth: 10
 node_js:
-  - 6
-  - 8
   - 10
   - 12
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,6 @@
 
 environment:
   matrix:
-  - nodejs_version: 6
-  - nodejs_version: 8
   - nodejs_version: 10
   - nodejs_version: 12
 

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "eslint": "eslint --ignore-path .gitignore ."
   },
   "engines": {
-    "node": ">= 6",
-    "npm": ">= 3"
+    "node": ">= 10",
+    "npm": ">= 5.6.0"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
### Motivation and Context

Next major release, `cordova-fetch@3.x` will no longer test or require code to be backwards compatible with node 6 and 8.

### Description

- Removes node 6 and 8 from testing and `package.json`.
- Updated minimum supported node and npm version.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
