### PR TITLE
chore: bump production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   },
   "dependencies": {
     "cordova-common": "^3.1.0",
-    "fs-extra": "^7.0.1",
-    "npm-package-arg": "^6.1.0",
+    "fs-extra": "^8.1.0",
+    "npm-package-arg": "^6.1.1",
     "pify": "^4.0.1",
-    "resolve": "^1.10.0",
-    "semver": "^5.6.0",
+    "resolve": "^1.12.0",
+    "semver": "^6.3.0",
     "which": "^1.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Motivation and Context

Update the third-party production npm dependencies to ensure that our package remains vulnerability free that can come from third-party dependencies.

Enables us to use new features, leverage speed improvements, and resolve issues that were caused by third-party dependency bugs.

### Description

Updated Dependencies

* fs-extra@^8.1.0
* npm-package-arg@^6.1.1
* resolve@^1.12.0
* semver@^6.3.0

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
