### PR TITLE
chore: refactor script naming convention

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,10 @@
     "rewire": "^4.0.1"
   },
   "scripts": {
-    "test": "npm run eslint && npm run cover",
-    "cover": "nyc jasmine",
-    "eslint": "eslint --ignore-path .gitignore ."
+    "eslint": "eslint --ignore-path .gitignore .",
+    "test": "npm run eslint && npm run test:coverage",
+    "test:unit": "jasmine --config=spec/support/jasmine.json",
+    "test:coverage": "nyc npm run test:unit"
   },
   "engines": {
     "node": ">= 6",


### PR DESCRIPTION
### Motivation and Context

Try to improve the script naming conventions by grouping like items with prefixes.

Currently using this pattern in Cordova Electron and would like to uniform all repos with the same convention.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass