### PR TITLE
chore: update nyc dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "file-url": "^2.0.2",
     "jasmine": "^3.3.1",
-    "nyc": "^13.3.0",
+    "nyc": "^14.1.1",
     "rewire": "^4.0.1"
   },
   "scripts": {


### PR DESCRIPTION
### Motivation and Context

Current version of `nyc` is bugged for `node >= 10`.

### Description

This PR updates the `nyc` dev dependency to the latest released version. The new version also continues to support `node >= 6` which fits current master.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
