### PR TITLE
Work around npm bug when uninstalling old cordova platforms

### DIFF
--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -89,21 +89,21 @@ describe('fetch/uninstall with --save', function () {
     it('should fetch and uninstall a cordova platform via npm & git tags/branches', function () {
         return Promise.resolve()
             // npm tag
-            .then(_ => fetchAndMatch('cordova-android@5.1.1', {
+            .then(_ => fetchAndMatch('cordova-android@8.1.0', {
                 name: 'cordova-android',
-                version: '5.1.1'
+                version: '8.1.0'
             }))
-            .then(_ => expectDependenciesToBe({ 'cordova-android': '^5.1.1' }))
+            .then(_ => expectDependenciesToBe({ 'cordova-android': '^8.1.0' }))
             .then(_ => uninstall('cordova-android', tmpDir, opts))
             .then(_ => expectDependenciesToBe({}))
             .then(_ => expectNotToBeInstalled('cordova-android'))
 
             // git tag
-            .then(_ => fetchAndMatch('https://github.com/apache/cordova-ios.git#rel/4.1.1', {
+            .then(_ => fetchAndMatch('https://github.com/apache/cordova-ios.git#rel/5.0.1', {
                 name: 'cordova-ios',
-                version: '4.1.1'
+                version: '5.0.1'
             }))
-            .then(_ => expectDependenciesToBe({ 'cordova-ios': 'git+https://github.com/apache/cordova-ios.git#rel/4.1.1' }))
+            .then(_ => expectDependenciesToBe({ 'cordova-ios': 'git+https://github.com/apache/cordova-ios.git#rel/5.0.1' }))
             .then(_ => uninstall('cordova-ios', tmpDir, opts))
             .then(_ => expectDependenciesToBe({}))
             .then(_ => expectNotToBeInstalled('cordova-ios'))


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When using `npm@>=6.11.0` on Windows, `npm uninstall` of `cordova-android@5.1.1` will leave an empty folder `node_modules/cordova-android/node_modules` behind. This causes one of our tests to fail but it is very likely an issue with npm. Furthermore this is very unlikely to affect users of `cordova-fetch` in production.


### Description
<!-- Describe your changes in detail -->
We just install a later version of `cordova-android` and `cordova-ios` in the test. The exact version or even package installed does not really matter, the test just asserts that a package can be installed and then uninstalled .


### Testing
<!-- Please describe in detail how you tested your changes. -->
CI tests are passing again.