### PR TITLE
doc(README): fix markdown lint warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@
 #
 -->
 
-[![Node CI](https://github.com/apache/cordova-fetch/workflows/Node%20CI/badge.svg?branch=master)](https://github.com/apache/cordova-fetch/actions?query=branch%3Amaster)
+# cordova-fetch
+
 [![NPM](https://nodei.co/npm/cordova-fetch.png)](https://nodei.co/npm/cordova-fetch/)
 
-# cordova-fetch
+[![Node CI](https://github.com/apache/cordova-fetch/workflows/Node%20CI/badge.svg?branch=master)](https://github.com/apache/cordova-fetch/actions?query=branch%3Amaster)
 
 This package can be used to install and uninstall Node.js packages using npm.
 


### PR DESCRIPTION
### Motivation and Context

Just decided to move the badges under the header to remove the linter warning to a tool I am using to make sure format is consistent.

https://github.com/DavidAnson/markdownlint/blob/v0.19.0/doc/Rules.md#md041 

This layout is also being applied to all other repo.

### Checklist

- [x] I've updated the documentation if necessary
