### PR TITLE
fix: do not pack rejections from resolve in array

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const npa = require('npm-package-arg');
 const semver = require('semver');
 
 // pify's multiArgs unfortunately causes resolve to wrap errors in an Array.
-// Thus we wrap the function again to unpack the errors from the rejec
+// Thus we wrap the function again to unpack these wrapped errors.
 const rslv = pify(require('resolve'), { multiArgs: true });
 const resolve = (...args) => rslv(...args).catch(([err]) => { throw err; });
 

--- a/index.js
+++ b/index.js
@@ -20,9 +20,13 @@ const which = pify(require('which'));
 const path = require('path');
 const fs = require('fs-extra');
 const { CordovaError, events, superspawn } = require('cordova-common');
-const resolve = pify(require('resolve'), { multiArgs: true });
 const npa = require('npm-package-arg');
 const semver = require('semver');
+
+// pify's multiArgs unfortunately causes resolve to wrap errors in an Array.
+// Thus we wrap the function again to unpack the errors from the rejec
+const rslv = pify(require('resolve'), { multiArgs: true });
+const resolve = (...args) => rslv(...args).catch(([err]) => { throw err; });
 
 /**
  * Installs a module from npm, a git url or the local file system.


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We use the package `resolve` to find out if a requested dependency is already installed. That package exports a callback based async API that we promisify using `pify`. Since the callback of `resolve` is called with multiple result arguments, we need to use the `multiArgs` option of `pify` here. Unfortunately that also wraps the errors of `resolve` into an array.

### Description
<!-- Describe your changes in detail -->
This PR unwraps the errors returned by our promisified `resolve`.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual