### PR TITLE
fix: use POSIX-style paths for require.resolve & Co

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ function resolvePathToPackage (name, basedir) {
 
         // We resolve the path to the module's package.json to avoid getting the
         // path to `main` which could be located anywhere in the package
-        return resolve(path.join(name, 'package.json'), { paths, basedir })
+        return resolve(`${name}/package.json`, { paths, basedir })
             .then(([pkgJsonPath, pkgJson]) => [
                 path.dirname(pkgJsonPath), pkgJson
             ]);


### PR DESCRIPTION
Although platform-specific paths usually work just fine, this is the way it should be (see https://nodejs.org/api/modules.html).