### PR TITLE
ci: test with Node 16 instead of 15 for already correct version of npm@7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -35,10 +35,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Update to npm@^7.2 on Node 15
-        if: matrix.node-version == '15.x'
-        run: npm i -g npm@^7.2
 
       - name: Environment Information
         run: |


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
test


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Node.js 16 is the future LTS and providing npm@7 > 7.2 already.


### Description
<!-- Describe your changes in detail -->
Use of node 16.x to replace 15.x with custom npm@7 update from #91.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Local `npm cit` success on:
* OS: Windows 10
* Node: 16.0.0
* npm: 7.10.0


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
