### PR TITLE
ci: sync codecov-action setup between other repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,6 @@ jobs:
           CI: true
 
       - uses: codecov/codecov-action@v3
+        if: success()
         with:
-          fail_ci_if_error: true
+          name: ${{ runner.os }} node.js ${{ matrix.node-version }}


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Sync recent changes made in other repos around CodeCov Action

### Description
<!-- Describe your changes in detail -->

Similar changes were taken from [cordova-common repo](https://github.com/apache/cordova-common/blob/master/.github/workflows/ci.yml#L49-L53).

* Did not copy over the `name` field. 
  * IMO GitHub Action's default name `Run codecov/codecov-action@v3` is sufficient. 
* Added the `if` field.
  * Only run CodeCov when successful.
* Added the `with` → `name` field. 
  * Improves CodeCov's Run Result Dashboard labeling. (Example: `4538518365` becomes `Linux node.js 18.x`)
* Dropped `fail_ci_if_error`.
  * Try to prevent CI failures that might be caused by CodeCov. E.g. failures to upload results. 

### Testing
<!-- Please describe in detail how you tested your changes. -->

Tested on external repo.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
