### PR TITLE
chore(ci): Fix dependabot code scanning errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,13 @@
 
 name: Node CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/*'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   test:


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Dependabot pushes a branch to the repo and opens a pull request. The pull request workflow runs properly, but the push workflow fails because dependabot doesn't have access to a read/write GITHUB_TOKEN and doesn't have access to the repo secrets.


### Description
<!-- Describe your changes in detail -->

The quick fix is telling CI not to run the push event workflow for branches that start with `dependabot/`.
