### PR TITLE
chore(ci): Add licence checker workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ name: Node CI
 on:
   push:
     branches-ignore:
-      - 'dependabot/*'
+      - 'dependabot/**'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/release-audit.yml
+++ b/.github/workflows/release-audit.yml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Release Auditing
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    name: Audit Licenses
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout project
+      - uses: actions/checkout@v4
+
+      # Check license headers
+      - uses: erisu/apache-rat-action@555ae80334a535eb6c1f8920b121563a5a985a75
+
+      # Setup environment with node
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Install node packages
+      - name: npm install packages
+        run: npm i
+
+      # Check node package licenses
+      - uses: erisu/license-checker-action@e929758f9416f30234ac454fc9054ca4b803871d
+        with:
+          license-config: 'licence_checker.yml'

--- a/.ratignore
+++ b/.ratignore
@@ -1,3 +1,4 @@
+\.(.*)
 jasmine.json
 testpkg.json
-*.git
+(.*).git

--- a/licence_checker.yml
+++ b/licence_checker.yml
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Compiled list of allowed 3RD PARTY LICENSES from:
+#
+# ASF CATEGORY A: WHAT CAN WE INCLUDE IN AN ASF PROJECT
+# https://www.apache.org/legal/resolved.html#category-a
+#
+# Licenses converted into the SPDX standardized short identifier format.
+# https://spdx.org/licenses/
+allowed-licenses:
+  - 0BSD
+  - AFL-3.0
+  - Apache-1.1
+  - Apache-2.0
+  - APAFML
+  - BlueOak-1.0.0
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - BSD-3-Clause-LBNL
+  - BSL-1.0
+  - CC-PDDC
+  - CC0-1.0
+  - EPICS
+  - HPND
+  - ICU
+  - ISC
+  - MIT
+  - MIT-0
+  - MS-PL
+  - MulanPSL-2.0
+  - NCSA
+  - OGL-UK-3.0
+  - PHP-3.01
+  - PostgreSQL
+  - PSF-2.0
+  - SMLNJ
+  - Unicode-DFS-2016
+  - Unlicense
+  - UPL-1.0
+  - W3C
+  - WTFPL
+  - X11
+  - Xnet
+  - Zlib
+  - ZPL-2.0
+  - Python-2.0
+
+ignored-packages:
+  - spdx-exceptions@2.5.0
+


### PR DESCRIPTION
### Platforms affected
all


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We want to ensure licence compliance at PR time.


### Description
<!-- Describe your changes in detail -->
* Add the licence checking action workflow
* Fix the dependabot workaround to actually work


### Testing
<!-- Please describe in detail how you tested your changes. -->
Ran in CI


### Checklist

- [x] I've run the tests to see all new and existing tests pass