### PR TITLE
test: drop file-url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
       },
       "devDependencies": {
         "@cordova/eslint-config": "^5.1.0",
-        "file-url": "^3.0.0",
         "jasmine": "^5.9.0",
         "nyc": "^17.1.0"
       },
@@ -2963,16 +2962,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/file-url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/file-url/-/file-url-3.0.0.tgz",
-      "integrity": "sha512-g872QGsHexznxkIAdK8UiZRe7SkE6kvylShU4Nsj8NvfvZag7S0QuQ4IgvPDkk75HxgjIVDwycFTDAgIiO4nDA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/fill-range": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@cordova/eslint-config": "^5.1.0",
-    "file-url": "^3.0.0",
     "jasmine": "^5.9.0",
     "nyc": "^17.1.0"
   },

--- a/spec/fetch.spec.js
+++ b/spec/fetch.spec.js
@@ -20,7 +20,6 @@ const uninstall = fetch.uninstall;
 
 const path = require('node:path');
 const fs = require('node:fs');
-const fileUrl = require('file-url');
 const helpers = require('./helpers.js');
 
 let tmpDir, opts;
@@ -142,7 +141,7 @@ describe('fetching already installed packages', () => {
     }, 40000);
 
     it('should return package path if git repo name differs from plugin id', () => {
-        const TARGET = `git+${fileUrl(path.resolve(__dirname, 'support/repo-name-neq-plugin-id.git'))}`;
+        const TARGET = `git+file://${path.resolve(__dirname, 'support/repo-name-neq-plugin-id.git')}`;
         return Promise.resolve()
             .then(_ => fetchAndMatch(TARGET, { name: 'test-plugin' }))
             .then(_ => fetchAndMatch(TARGET, { name: 'test-plugin' }));
@@ -191,7 +190,7 @@ describe('fetching with node_modules in ancestor dirs', () => {
 
         // Copy test fixtures to avoid linking out of temp directory
         fs.cpSync(path.join(__dirname, 'support'), 'support', { recursive: true });
-        fetchTarget = fileUrl(path.resolve('support/dummy-local-plugin'));
+        fetchTarget = `file://${path.resolve('support/dummy-local-plugin')}`;
     });
 
     it('should still install to given destination', () => {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

`file-url` has switched to pure ESM in newer version and cannot be updated in dependencies. And `file-url` is used in test script only to convert path to file URL without file encoding. It looks excessive to use third-party node modules.

### Description
<!-- Describe your changes in detail -->

Drop `file-url` add `file://` to path in test script.  At first I tried to use node default library `url.pathToFileURL()` but it causes error in windows because `url.pathToFileURL()` also converts unnecessary URL encoding.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
